### PR TITLE
Review and correct some translations of English

### DIFF
--- a/en/en.po
+++ b/en/en.po
@@ -17,13 +17,13 @@ msgstr "“Who poked my screen?”"
 msgid "他会让你的屏幕看起来坏掉了一块，仅此而已。\n"
 "当你看到他时说明当前道具池已经空了。"
 msgstr "He makes your screen look broken. That's all.\n"
-"When you see him, the current item pool is empty."
+"When you see him, it means the current item pool is empty."
 
 msgid "机魂"
 msgstr "Mech Soul"
 
 msgid "“愿人类，荣光永存。”"
-msgstr "“May humanity's glory last forever.”"
+msgstr "“May the glory of humanity last forever.”"
 
 msgid "根据持有机魂数量执行效果：\n"
 "1个：生成一个阻挡子弹的小机器人环绕物。\n"
@@ -32,8 +32,8 @@ msgid "根据持有机魂数量执行效果：\n"
 "4个及以上：重复以上步骤。"
 msgstr "Effects based on the number of Mech Souls:\n"
 "1: A small robot orbits to block bullets.\n"
-"2: The robot doesn't disappear after blocking and deals physical damage to contacting units.\n"
-"3: The robot follows and auto-fires bullets, dealing physical damage.\n"
+"2: The robot no longer disappears after blocking damage and deals physical damage to the contacted units.\n"
+"3: The robot no longer orbits the character, but instead follows them, automatically shooting bullets which deal physical damage.\n"
 "4+: Repeats the above steps."
 
 msgid "读取存档"
@@ -83,19 +83,19 @@ msgstr "“I forgive you.”"
 
 msgid "治疗效果生效会同时为你提供经验值。\n"
 "每回合这个效果提供的经验值有上限。"
-msgstr "Healing grants experience points.\n"
+msgstr "Healing grants XP.\n"
 "Each turn has an XP cap for this effect."
 
 msgid "人鱼回响"
 msgstr "Mermaid Echo"
 
 msgid "“和我一起成为偶像吧！”"
-msgstr "“Become an idol with me!”"
+msgstr "“Become an idol together with me!”"
 
 msgid "近战武器一次挥动命中敌人超过3个时，会在面前区域内形成一个恢复法阵。\n"
 "法阵持续2s，走入法阵可以恢复{{0}}-{{1}}（根据已损血量提升）\n"
 "这个效果有4秒的冷却。"
-msgstr "After hitting 3+ enemies with a melee swing, a healing array appears.\n"
+msgstr "After hitting 3+ enemies at once with a melee swing, a healing array appears.\n"
 "Lasts 2s, restores {{0}}-{{1}} HP (based on damage taken).\n"
 "4s cooldown."
 
@@ -119,13 +119,13 @@ msgstr "Designed to shoot through targets."
 msgid "为你的远程武器提供贯穿能力。\n"
 "但每贯穿一个目标，该子弹伤害衰减为当前的50%。"
 msgstr "Gives your ranged weapons penetration.\n"
-"Each target reduces bullet damage by 50%."
+"Each penetration reduces bullet damage by 50%."
 
 msgid "板砖"
 msgstr "Brick"
 
 msgid "武功再高，也怕菜刀。智力再好，一砖撂倒。"
-msgstr "No matter how skilled, a kitchen knife can hurt. No matter how smart, a brick can take you down."
+msgstr "No martial arts match a blade, no wisdom withstands a brick."
 
 msgid "大力丸"
 msgstr "Strength Pill"
@@ -134,13 +134,13 @@ msgid "江湖骗子的常用伎俩。"
 msgstr "A common trick of charlatans."
 
 msgid "非酋"
-msgstr "Unlucky One"
+msgstr "Jinx"
 
 msgid "“这游戏有SR吗？”"
 msgstr "“Does this game have SR?”"
 
 msgid "物理必修二"
-msgstr "Physics Required II"
+msgstr "Physics Fundamentals"
 
 msgid "——讲科学，破迷信。"
 msgstr "Promoting science, dispelling superstition."
@@ -155,7 +155,7 @@ msgid "雅各布天梯"
 msgstr "Jacob's Ladder"
 
 msgid "“赐我圣火！”"
-msgstr "“Grant me holy fire!”"
+msgstr "“Grant me the holy fire!”"
 
 msgid "你的暴击伤害会对首次命中的目标产生一次{{0}}的电弧伤害。\n"
 "你每持有一个雅各布天梯，电弧伤害即可多连接一个目标。\n"
@@ -168,12 +168,12 @@ msgid "双持"
 msgstr "Dual Wield"
 
 msgid "像个战神！"
-msgstr "Like a war god!"
+msgstr "Like a god of war!"
 
 msgid "战斗时同时使用所有已装备的武器。\n"
 "但你的伤害修正为{{0}}。"
 msgstr "Use all equipped weapons simultaneously in combat.\n"
-"Damage is modified by {{0}}."
+"But the damage is adjusted to {{0}}."
 
 msgid "IX.隐者"
 msgstr "IX. The Hermit"
@@ -197,20 +197,20 @@ msgid "VII.战车"
 msgstr "VII. The Chariot"
 
 msgid "本能与意志。"
-msgstr "Instinct and Will."
+msgstr "Instinct and Willpower."
 
 msgid "当生命值少于50%时，根据已损生命值增加至多50%伤害倍率修正。"
-msgstr "Below 50% HP, damage increases by up to 50% based on HP lost."
+msgstr "When HP is below 50%, the damage multiplier will increase by up to 50% based on HP lost."
 
 msgid "XVI.塔"
 msgstr "XVI. The Tower"
 
 msgid "终将倒塌。"
-msgstr "It will fall eventually."
+msgstr "Will inevitably crumble."
 
 msgid "每{{0}}暴击率提供的{{1}}伤害倍率乘数修正。\n"
 "普通攻击无法暴击。"
-msgstr "Each {{0}} crit chance grants {{1}} damage multiplier.\n"
+msgstr "Each {{0}} crit rate provides a {{1}} damage multiplier adjustment.\n"
 "Normal attacks cannot crit."
 
 msgid "通缉上升！"
@@ -230,8 +230,8 @@ msgstr "Fortune is fickle, fate is certain."
 
 msgid "允许你消耗幸运重置当前道具选择。\n"
 "单回合内多次使用会增大消耗。"
-msgstr "Spend luck to reset current item selection.\n"
-"Cost increases with multiple uses per turn."
+msgstr "Allow you to spend luck to reset current item selection.\n"
+"Using multiple times in a single round will increase the cost."
 
 msgid "0.愚者"
 msgstr "0. The Fool"
@@ -240,7 +240,7 @@ msgid "愚者之旅。"
 msgstr "The Fool's Journey."
 
 msgid "按照等级次序移除最早获得的最多3个道具，补偿对应数目的剩余道具掉落。"
-msgstr "Remove up to 3 earliest acquired items by level order, compensating with remaining item drops."
+msgstr "Remove up to 3 earliest acquired items by level order, compensating with the corresponding number of remaining item drops."
 
 msgid "II.女祭司"
 msgstr "II. The High Priestess"
@@ -273,7 +273,7 @@ msgid "可以坐的椅子"
 msgstr "Sittable Chair"
 
 msgid "3A大作的门槛（确信"
-msgstr "The threshold of a triple-A title (convinced)"
+msgstr "The threshold of an AAA masterpiece (convinced"
 
 msgid "回合结束时恢复一定血量。"
 msgstr "Restores some HP at the end of the round."
@@ -285,13 +285,13 @@ msgid "调和。"
 msgstr "Harmonize."
 
 msgid "放弃获取武器或道具时，你可以获得一次属性提升。"
-msgstr "Renounce a weapon or item to gain a stat boost."
+msgstr "You can gain a stat boost when discarding a weapon or an item."
 
 msgid "库因克"
-msgstr "Quincunx"
+msgstr "Quinque"
 
 msgid "“吃吧……”"
-msgstr "“Eat...""
+msgstr "“Eat then...”"
 
 msgid "每秒失去1点生命（不会导致角色死亡）。"
 msgstr "Lose 1 HP per second (won't kill the character)."
@@ -304,14 +304,14 @@ msgstr "“The Great Sage has returned!”"
 
 msgid "挥起棍子，抵御一切！\n"
 "每3次近战武器攻击的挥砍可以抵挡飞行道具。"
-msgstr "Wield the staff to block everything!\n"
+msgstr "Wield the staff, resist everything!\n"
 "Every 3rd melee attack blocks projectiles."
 
 msgid "VI.恋人"
 msgstr "VI. The Lovers"
 
 msgid "他、她或者它，会拯救你。"
-msgstr "He, she, or it will save you."
+msgstr "He, she, or it, will save you."
 
 msgid "回合结束后自动回收所有未拾取的药瓶。"
 msgstr "Automatically recovers all unpicked potions after each round."
@@ -323,7 +323,7 @@ msgid "来个“XX饮品”给我打钱谢谢！"
 msgstr "Send me money for “XX Beverage” please!"
 
 msgid "提升药瓶的恢复能力。"
-msgstr "Enhances potion recovery power."
+msgstr "Enhances potion's recovery ability."
 
 msgid "圣水"
 msgstr "Holy Water"
@@ -345,7 +345,7 @@ msgid "总有人要偿还罪孽。"
 msgstr "Someone must atone for sins."
 
 msgid "放弃道具时，可获得道具+1。"
-msgstr "Renounce an item to gain +1 item capacity."
+msgstr "You can gain another item when discarding an item."
 
 msgid "杀意之波动"
 msgstr "Wave of Murderous Intent"
@@ -362,23 +362,23 @@ msgid "1UP蘑菇"
 msgstr "1UP Mushroom"
 
 msgid "加一条命！"
-msgstr "Extra life!"
+msgstr "An extra life!"
 
 msgid "角色死亡时，会以当前生命的50%原地复生。\n"
 "生效后移除此道具。"
-msgstr "Revives with 50% HP when character dies.\n"
+msgstr "Revives with 50% HP when the character dies.\n"
 "Consumed upon activation."
 
 msgid "蓝色方块"
 msgstr "Blue Cube"
 
 msgid "过去并未消逝，甚至并未过去。"
-msgstr "The past is never dead. It isn't even past."
+msgstr "The past has never vanished, nor has it truly passed."
 
 msgid "回到上一波次。\n"
 "永久提升敌人强度。"
 msgstr "Return to the previous wave.\n"
-"Permanently increases enemy strength."
+"Permanently increases the enemies' strength."
 
 msgid "XV.恶魔"
 msgstr "XV. The Devil"
@@ -393,28 +393,28 @@ msgid "I.魔术师"
 msgstr "I. The Magician"
 
 msgid "变化莫测，心想事成。"
-msgstr "Unpredictable changes, wishes come true."
+msgstr "The winds of change are unpredictable; the desires of heart are fulfilled."
 
 msgid "胡桃"
 msgstr "Walnut"
 
 msgid "\"他们的火力只能让我感到一种麻麻的感觉，像是……令人放松的背部按摩。”"
-msgstr "\"Their firepower only gives me a tingling sensation, like... a relaxing back massage.""
+msgstr "“Their firepower only gives me a tingling sensation, like... a relaxing back massage.”"
 
 msgid "生成一个可以抵挡子弹的环绕物。"
 msgstr "Creates an orb that blocks bullets."
 
 msgid "懒骨头"
-msgstr "Lazy Bones"
+msgstr "Lazybones"
 
 msgid "“找八份工作就有八份假期。”"
-msgstr "“Get eight jobs for eight vacations.”"
+msgstr "“Having eight jobs means having eight vacations.”"
 
 msgid "停止移动时，法术强度修正+25%。"
-msgstr "Spell power +25% when not moving."
+msgstr "Spell power +25% when stationary."
 
 msgid "勤快骨头"
-msgstr "Diligent Bones"
+msgstr "Diligentbones"
 
 msgid "“人类！”"
 msgstr "“Humanity!”"
@@ -423,7 +423,7 @@ msgid "Rabot-2333"
 msgstr "Rabot-2333"
 
 msgid "把接下来的一个 \"hurt\" 转化为 \"block\" ~"
-msgstr "Convert the next \"hurt\" to \"block\" ~"
+msgstr "Convert the next “hurt” to “block”~"
 
 msgid "回合开始时获得一个护盾。"
 msgstr "Gain a shield at the start of each turn."
@@ -432,24 +432,24 @@ msgid "大生命药水"
 msgstr "Greater Health Potion"
 
 msgid "“喝得更爽！”"
-msgstr "“Drink better!”"
+msgstr "“Drink more refreshingly!”"
 
 msgid "掉落的生命药水有 50% 的概率变为大生命药水。\n"
 "拾取大生命药水时，额外恢复角色{{0}}生命值。"
 msgstr "Health potions have a 50% chance to become Greater.\n"
-"Picking up Greater restores {{0}} extra HP."
+"Picking up Greater Health Potion restores an EXTRA {{0}} HP."
 
 msgid "无响应"
 msgstr "No Response"
 
 msgid "按 Ctrl + Alt + Delete 打开任务管理器。"
-msgstr "Press Ctrl + Alt + Delete to open Task Manager."
+msgstr "Press Ctrl + Alt + Delete to open the Task Manager."
 
 msgid "弹幕"
 msgstr "Bullet Hell"
 
 msgid "——因为太长了看不清所以必须要慢下来……"
-msgstr "—Too long to see clearly, must slow down..."
+msgstr "—Too long to see clearly, have no choice but to slow down..."
 
 msgid "神经网络"
 msgstr "Neural Network"
@@ -458,7 +458,7 @@ msgid "21世纪最伟大的发明。"
 msgstr "The greatest invention of the 21st century."
 
 msgid "等级提升时，额外使你的{{0}}和{{1}}两者中最高的属性+2。"
-msgstr "On leveling up, add +2 to the higher of {{0}} or {{1}}."
+msgstr "On leveling up, add 2 to the higher of {{0}} and {{1}}."
 
 msgid "魂火"
 msgstr "Soul Flame"
@@ -467,13 +467,13 @@ msgid "燃尽你的灵魂。"
 msgstr "Consume your soul."
 
 msgid "每回合自动生成2个白色魂火，对接触到的敌人造成{{0}}伤害，或抵挡飞行道具。生效后会消失。"
-msgstr "Automatically generate 2 white Soul Flames per turn. Deal {{0}} damage to enemies or block projectiles. Disappear after activation."
+msgstr "Automatically generate 2 white Soul Flames per round, dealing {{0}} damage to enemies or blocking projectiles. Disappears after activation."
 
 msgid "XIX.太阳"
 msgstr "XIX. The Sun"
 
 msgid "洞察一切真相，但权力在你手上。"
-msgstr "See all truths, but power is in your hands."
+msgstr "See all truths, yet the power is in your hands."
 
 msgid "环绕物变远。"
 msgstr "Orbital objects move farther away."
@@ -494,10 +494,10 @@ msgid "暴击暴击"
 msgstr "Crit Overload"
 
 msgid "特别狠的一下。"
-msgstr "A particularly vicious hit."
+msgstr "A particularly heavy strike."
 
 msgid "暴击率每超过100%，可固定多享有一次暴击收益，不足100%的部分可以再次判定暴击。"
-msgstr "Each 100% crit rate grants an additional guaranteed crit. The remainder can crit again."
+msgstr "Each 100% crit rate provides an extra crit bonus on each hit. And the remaining crit rate will have a chance to trigger another crit."
 
 msgid "蜕变挽歌"
 msgstr "Elegy of Metamorphosis"
@@ -506,13 +506,13 @@ msgid "为武器灌输神圣的力量。"
 msgstr "Infuse weapons with sacred power."
 
 msgid "生命大于50%时，普通攻击会释放和当前武器攻击相当的剑气。"
-msgstr "Normal attacks release sword waves equivalent to current weapon when HP >50%."
+msgstr "When HP >50%, normal attacks will release sword waves with the same attack power as the current weapon."
 
 msgid "弱欲之壶"
 msgstr "Vessel of Weak Desire"
 
 msgid "自己从卡组抽两张。"
-msgstr "Draw two cards from your deck."
+msgstr "Draw two cards from the deck on your own."
 
 msgid "可获得道具 +2"
 msgstr "+2 obtainable items"
@@ -532,10 +532,10 @@ msgid "计分板"
 msgstr "Scoreboard"
 
 msgid "只要我掉血的够快，死亡就追不上我！"
-msgstr "If I lose HP fast enough, death can't catch me!"
+msgstr "As long as I lose HP fast enough, death will never catch up with me!"
 
 msgid "受到的伤害会缓慢结算，回合结束时清空未结算的剩余伤害。"
-msgstr "Damage is settled slowly, with remaining unsettled damage cleared at the end of the turn."
+msgstr "Damage is settled gradually and slowly, with remaining unsettled damage cleared at the end of the round."
 
 msgid "银弹"
 msgstr "Silver Bullet"
@@ -544,7 +544,7 @@ msgid "解决一切问题。"
 msgstr "Solves all problems."
 
 msgid "远程武器贯穿伤害不再衰减。"
-msgstr "Ranged penetration damage no longer decays."
+msgstr "The penetration damage of ranged weapons no longer reduces."
 
 msgid "XIX.月亮"
 msgstr "XIX. The Moon"
@@ -553,10 +553,10 @@ msgid "照亮你的内心。"
 msgstr "Illuminates your inner self."
 
 msgid "暴击会在敌人所在的位置产生一枚可以贯穿大量敌人的冰霜子弹，造成{{0}}伤害并暴击。\n"
-"每多持有一个月亮，会多产生一枚随机方向的冰霜子弹，但这枚子弹不会对中央的敌人造成更多次伤害。\n"
+"每多持有一个月亮，会多产生一枚随机方向的冰霜modified子弹，但这枚子弹不会对中央的敌人造成更多次伤害。\n"
 "这个效果有1秒的冷却。"
-msgstr "Crits create a frost bullet at the enemy's position that penetrates many enemies, dealing {{0}} damage and critting.\n"
-"Each additional Moon creates another frost bullet in a random direction, but it won't hit the central enemy multiple times.\n"
+msgstr "Crits create a frost bullet at the enemy's position that can penetrate many enemies, dealing {{0}} damage and critting.\n"
+"Each Moon creates an extra frost bullet in a random direction, but it won't deal more damage to the central enemy.\n"
 "1s cooldown."
 
 msgid "XXI.审判"
@@ -566,37 +566,37 @@ msgid "唤醒潜能，自我审判。"
 msgstr "Awaken potential, judge yourself."
 
 msgid "每次升级降低1点攻击力。"
-msgstr "Loses 1 attack power each level up."
+msgstr "Each level up reduces attack power by 1."
 
 msgid "IV.皇帝"
 msgstr "IV. The Emperor"
 
 msgid "无法违抗。"
-msgstr "Cannot be disobeyed."
+msgstr "Cannot disobey."
 
 msgid "在有BOSS的回合开始时，获得一个护盾。"
-msgstr "Gain a shield at the start of rounds with a BOSS."
+msgstr "Gain a shield at the start of the rounds with a BOSS."
 
 msgid "VIII.力量"
 msgstr "VIII. Strength"
 
 msgid "并非蛮力。"
-msgstr "Not brute strength."
+msgstr "Not brute force."
 
 msgid "合并图层"
 msgstr "Merge Layers"
 
 msgid "坏了！撤不回了！"
-msgstr "Broken! Can't undo!"
+msgstr "Broken! Cannot undo!"
 
 msgid "所有属性不再下降。"
-msgstr "All attributes stop decreasing."
+msgstr "All stats no longer decreases."
 
 msgid "看板娘"
-msgstr "Mascot Girl"
+msgstr "Kanban Musume"
 
 msgid "所有的可选角色都是这位cosplay的。"
-msgstr "All playable characters are cosplayed by her."
+msgstr "All available characters are cosplayed by her."
 
 msgid "骑士"
 msgstr "Knight"
@@ -605,7 +605,7 @@ msgid "其实这是一件盔甲，你只需要穿上它就好。战斗几乎是�
 msgstr "This is actually a suit of armor. Just wear it. Combat is almost fully automatic."
 
 msgid "升级时以随机属性提升来代替自由加点。"
-msgstr "Random attribute increases on leveling instead of free point allocation."
+msgstr "Random stat increases on leveling up instead of free point allocation."
 
 msgid "树"
 msgstr "Tree"
@@ -615,27 +615,27 @@ msgstr "Merry Christmas!"
 
 msgid "受到接触伤害时反弹同等伤害并击退。\n"
 "移动速度修正为20%。"
-msgstr "Reflect equal damage and knockback on contact damage.\n"
+msgstr "Reflect equal damage and knockback when receiving contact damage.\n"
 "Movement speed modified to 20%."
 
 msgid "土豆"
 msgstr "Potato"
 
 msgid "拯救被异形占领的星球幸存者。"
-msgstr "Save survivors on a planet occupied by aliens."
+msgstr "Save survivors on the planet occupied by aliens."
 
 msgid "每两回合可以获得一把新武器，最多可以同时装备六把武器。\n"
 "每多装备一把武器会带来更低的伤害修正。"
 msgstr "Gain a new weapon every two rounds. Max six equipped weapons.\n"
-"Each additional weapon reduces damage modification."
+"Each additional weapon equipped applies a lower damage modification."
 
 msgid "狩龙人"
 msgstr "Dragon Hunter"
 
 msgid "每次攻击动作会受到2点献祭伤害并积攒1点怒气，切换武器时怒气会重新计量。\n"
 "怒气累计到达5点时，切换武器后的第一次攻击为会造成巨额伤害的狂怒攻击。若此伤害为近战武器造成，则根据此伤害恢复自身生命值（这个恢复效果不会超过最大生命值的20%）。"
-msgstr "Each attack deals 2 sacrifice damage and generates 1 rage. Rage resets when switching weapons.\n"
-"At 5 rage, the first attack after switching is a furious attack dealing massive damage. If from a melee weapon, recover HP based on the damage (capped at 20% max HP)."
+msgstr "Each attack deals 2 points of sacrifice damage and generates 1 point of rage. Rage resets when switching weapons.\n"
+"When rage accumulates to 5, the first attack after switching the weapon will be a furious attack dealing massive damage. If this damage is caused by a melee weapon, recover HP based on the damage (capped at 20% max HP)."
 
 msgid "神社巫女"
 msgstr "Shrine Maiden"
@@ -643,9 +643,9 @@ msgstr "Shrine Maiden"
 msgid "攻击会积攒魂火，最多8团。这个效果有3秒冷却时间。\n"
 "魂火会环绕在角色周围，帮助角色抵挡子弹，并对接触的敌人造成200%的魔法伤害。\n"
 "持有魂火会使你的攻击力下降。"
-msgstr "Attacks generate Soul Flames (max 8). 3s cooldown.\n"
-"Soul Flames orbit the character, block bullets, and deal 200% magical damage to contacting enemies.\n"
-"Having Soul Flames reduces attack power."
+msgstr "Attacks can generate Soul Flames (max 8). 3s cooldown.\n"
+"Soul Flames will orbit the character, block bullets, and deal 200% magical damage to contacted enemies.\n"
+"Having Soul Flames will reduce your attack power."
 
 msgid "精灵"
 msgstr "Elf"
@@ -706,17 +706,17 @@ msgid "升级所需的经验值更多。\n"
 "获取经验值同时获取等量金币，回合结束时可以使用金币购买道具。\n"
 "宝箱不再提供自选道具，改为获得金币。"
 msgstr "Requires more XP to level up.\n"
-"Gaining XP also grants equal amount of gold. Use gold to buy items at the end of rounds.\n"
+"Gaining XP also grants the same amount of gold, which can be used to buy items at the end of rounds.\n"
 "Chests no longer provide selectable items, instead grant gold."
 
 msgid "盗贼"
 msgstr "Rogue"
 
 msgid "花枝丸说用手柄玩特别有意思！"
-msgstr "Kazemaru says playing with a controller is especially fun!"
+msgstr "Hua-zhi-wan says it’s especially fun to play with a gamepad!"
 
 msgid "更灵活的指定攻击方位。"
-msgstr "More flexible attack direction specification."
+msgstr "More flexibility in specifying attack directions."
 
 msgid "爱丽丝"
 msgstr "Alice"
@@ -727,7 +727,7 @@ msgstr "Fall into hysterical madness..."
 msgid "生命归零时进入癫狂状态，每秒持续流血{{0}}并获得{{1}}生命偷取（普通攻击产生击杀时恢复生命）。\n"
 "这个效果每回合限一次，每次触发永久增加{{2}}伤害倍率。"
 msgstr "Enter frenzy state when HP hits zero, bleeding {{0}} per second and gaining {{1}} life steal (restore HP on normal attack kills).\n"
-"This effect triggers once per round, permanently increasing damage multiplier by {{2}} each time."
+"This effect triggers only once per round, permanently increasing damage multiplier by {{2}} each time."
 
 msgid "色欲"
 msgstr "Lust"
@@ -737,8 +737,8 @@ msgstr "Lust."
 
 msgid "你的生命上限修正为{{0}}，同时失去所有生命恢复手段。\n"
 "但你的生命值会在回合开始时从满状态重新计算。"
-msgstr "Your max HP is modified to {{0}}, and you lose all HP recovery methods.\n"
-"However, your HP is recalculated from full at the start of each round."
+msgstr "Your max HP is modified to {{0}}, and you lose all means of HP recovery.\n"
+"But your HP is recalculated from full at the start of each round."
 
 msgid "贪婪"
 msgstr "Greed"
@@ -748,8 +748,8 @@ msgstr "Greed."
 
 msgid "经验收益翻倍。\n"
 "但无法选择升级属性。"
-msgstr "Double experience gains.\n"
-"Cannot select attributes to upgrade."
+msgstr "Double XP gains.\n"
+"Cannot select stats to upgrade."
 
 msgid "懒惰"
 msgstr "Sloth"
@@ -759,8 +759,8 @@ msgstr "Sloth."
 
 msgid "将你的攻击力转化为 50% 的法术强度修正。\n"
 "但你的额外移速修正为 25%。"
-msgstr "Converts your attack power to 50% spell power modification.\n"
-"Additional movement speed is modified to 25%."
+msgstr "Converts your attack power into a 50% spell power modification.\n"
+"But your additional movement speed is modified to 25%."
 
 msgid "愤怒"
 msgstr "Wrath"
@@ -771,7 +771,7 @@ msgstr "Wrath."
 msgid "你的伤害倍率修正为 120%。\n"
 "但你的护甲修正为 20%。"
 msgstr "Your damage multiplier is modified to 120%.\n"
-"Armor is modified to 20%."
+"But your armor is modified to 20%."
 
 msgid "嫉妒"
 msgstr "Envy"
@@ -790,8 +790,8 @@ msgstr "Pride."
 
 msgid "将你的法术强度转化为 50% 的攻击力修正。\n"
 "但你的额外攻击范围修正为 50%。"
-msgstr "Converts your spell power to 50% attack power modification.\n"
-"Additional attack range is modified to 50%."
+msgstr "Converts your spell power into a 50% attack power modification.\n"
+"But your additional attack range is modified to 50%."
 
 msgid "暴食"
 msgstr "Gluttony"
@@ -800,7 +800,7 @@ msgid "Gluttony."
 msgstr "Gluttony."
 
 msgid "自动拾取所有掉落的经验。"
-msgstr "Automatically picks up all dropped experience."
+msgstr "Automatically picks up all dropped XP."
 
 msgid "慷慨"
 msgstr "Charity"
@@ -809,7 +809,7 @@ msgid "Charity."
 msgstr "Charity."
 
 msgid "升级时，你的属性品质提高一个等级。"
-msgstr "Attribute quality increases by one grade on leveling up."
+msgstr "Your stat quality increases by one grade on leveling up."
 
 msgid "贞洁"
 msgstr "Chastity"
@@ -827,7 +827,7 @@ msgid "Diligence."
 msgstr "Diligence."
 
 msgid "获得等同于等级的攻击力修正。"
-msgstr "Gains attack power modification equal to level."
+msgstr "Gains an attack power modification equal to the level."
 
 msgid "温和"
 msgstr "Patience"
@@ -837,8 +837,8 @@ msgstr "Patience."
 
 msgid "成功闪避攻击时恢复生命值。\n"
 "闪避修正+20%，允许溢出闪避属性上限。"
-msgstr "Restores HP on successful dodge.\n"
-"Dodge modification +20%, allowing exceedance of dodge attribute cap."
+msgstr "Restores HP after successful dodge.\n"
+"Dodge modification +20%, allowing exceedance of dodge stat cap."
 
 msgid "宽容"
 msgstr "Kindness"
@@ -856,7 +856,7 @@ msgid "Humility."
 msgstr "Humility."
 
 msgid "获得等同于等级的法术强度修正。"
-msgstr "Gains spell power modification equal to level."
+msgstr "Gains a spell power modification equal to the level."
 
 msgid "节制"
 msgstr "Temperance"
@@ -865,7 +865,7 @@ msgid "Temperance."
 msgstr "Temperance."
 
 msgid "自动拾取所有掉落的经验。"
-msgstr "Automatically picks up all dropped experience."
+msgstr "Automatically picks up all dropped XP."
 
 msgid "空手"
 msgstr "Unarmed"
@@ -889,7 +889,7 @@ msgid "无锋剑"
 msgstr "Edgeless Sword"
 
 msgid "“少年人的梦想，踏上旅途的兴奋。”"
-msgstr "“A young man's dream, the excitement of setting off on a journey.”"
+msgstr "“The dream of a young man, the excitement of setting off on a journey.”"
 
 msgid "AK47"
 msgstr "AK47"
@@ -898,7 +898,7 @@ msgid "在现代战争的钢铁风暴中，AK-47以其无与伦比的耐用性�
 msgstr "In the steel storms of modern warfare, the AK-47 has become a legend on the battlefield with its unparalleled durability and lethal firepower."
 
 msgid "光子法杖"
-msgstr "Photon Staff"
+msgstr "Photon Magic Staff"
 
 msgid "有什么东西能快得过光呢？"
 msgstr "What can be faster than light?"
@@ -925,10 +925,10 @@ msgid "手里剑"
 msgstr "Shuriken"
 
 msgid "每一名忍者的必备武器，更是那些精通潜行和暗杀技巧的战士们的得力助手。"
-msgstr "An essential weapon for every ninja, and a trusted assistant for warriors skilled in stealth and assassination."
+msgstr "An essential weapon for every ninja, and even a trusted assistant for warriors skilled in stealth and assassination."
 
 msgid "火焰法杖"
-msgstr "Flame Staff"
+msgstr "Flame Magic Staff"
 
 msgid "有什么东西能烧得过火呢？"
 msgstr "What can burn hotter than fire?"
@@ -949,13 +949,13 @@ msgid "弹弓"
 msgstr "Slingshot"
 
 msgid "“半夜打你家玻璃！”"
-msgstr "“Breaking your windows at midnight!”"
+msgstr "“Break your windows at midnight!”"
 
 msgid "苦无"
 msgstr "Kunai"
 
 msgid "每一名忍者的必备武器，更是那些行走在阴影中的刺客们的首选武器。"
-msgstr "An essential weapon for every ninja, and the preferred weapon for assassins who walk in shadows."
+msgstr "An essential weapon for every ninja, and even the preferred weapon for assassins who walk in shadows."
 
 msgid "灵体长矛"
 msgstr "Ethereal Spear"
@@ -973,7 +973,7 @@ msgid "空手？"
 msgstr "Unarmed?"
 
 msgid "觉醒了杀意之波动，即便赤手空拳也能爆发出强大的杀伤力。"
-msgstr "Awakened the波动 of murderous intent, even unarmed can unleash powerful killing power."
+msgstr "Awakened the wave of murderous intent, can unleash powerful killing power，even though unarmed."
 
 msgid "妈妈的菜刀"
 msgstr "Mom's Kitchen Knife"
@@ -991,7 +991,7 @@ msgid "M870"
 msgstr "M870"
 
 msgid "在现代战场中，M870以其泵动式的威力和模块化的灵活性，成为了战士们手中的毁灭使者。"
-msgstr "On modern battlefields, the M870 has become a harbinger of destruction for warriors with its pump-action power and modular flexibility."
+msgstr "In modern battlefields, the M870 has become a harbinger of destruction for warriors with its pump-action power and modular flexibility."
 
 msgid "十字架"
 msgstr "Crucifix"
@@ -1009,13 +1009,13 @@ msgid "新手"
 msgstr "Novice"
 
 msgid "完成一轮游戏。"
-msgstr "Complete one round of the game."
+msgstr "Finish the game once."
 
 msgid "老手"
 msgstr "Veteran"
 
 msgid "通关一轮游戏。"
-msgstr "Clear one round of the game."
+msgstr "Clear the game once."
 
 msgid "好身手！"
 msgstr "Great skills!"
@@ -1039,7 +1039,7 @@ msgid "暗影魔术手"
 msgstr "Shadow Magician"
 
 msgid "持有【伤害类型为法术的武器】通关。"
-msgstr "Clear the game with weapons of spell damage type."
+msgstr "Clear the game with [weapons of spell damage type]."
 
 msgid "长手"
 msgstr "Long Arm"
@@ -1066,7 +1066,7 @@ msgid "通关时持有道具数量不超过 20。"
 msgstr "Clear the game with no more than 20 items."
 
 msgid "运营大师欧菲手"
-msgstr "Operations Master O'Fei Hand"
+msgstr "Operations Master Orphen's Hand"
 
 msgid "使用角色【土豆】时获取了道具【双持】。"
 msgstr "Acquire the item [Dual Wield] when using the character [Potato]."
@@ -1075,7 +1075,7 @@ msgid "圣手"
 msgstr "Holy Hand"
 
 msgid "获得一次5级具。"
-msgstr "Obtain a level 5 item once."
+msgstr "Obtain a level 5 item."
 
 msgid "我全都要（伸手）！"
 msgstr "I want it all (reach out)!"
@@ -1084,10 +1084,10 @@ msgid "获得道具【坏点】。"
 msgstr "Acquire the item [Bad Spot]."
 
 msgid "我还留了一手！"
-msgstr "I've kept one more!"
+msgstr "I kept a trick up my sleeve!"
 
 msgid "通关时持有复活道具。"
-msgstr "Clear the game while holding a revival item."
+msgstr "Hold a revival item when clearing the game."
 
 msgid "空手？"
 msgstr "Unarmed?"
@@ -1144,13 +1144,13 @@ msgid "在标准难度下使用【神社巫女】通关游戏。"
 msgstr "Clear the game on Standard difficulty using [Shrine Maiden]."
 
 msgid "修行还在继续……"
-msgstr "Training continues..."
+msgstr "The spiritual practice continues..."
 
 msgid "在标准难度下使用【精灵】通关游戏。"
 msgstr "Clear the game on Standard difficulty using [Elf]."
 
 msgid "修行刚刚开始！"
-msgstr "Training has just begun!"
+msgstr "The spiritual practice has just begun!"
 
 msgid "在标准难度下使用【勇者】通关游戏。"
 msgstr "Clear the game on Standard difficulty using [Hero]."
@@ -1186,7 +1186,7 @@ msgid "在标准难度下使用【商人】通关游戏。"
 msgstr "Clear the game on Standard difficulty using [Merchant]."
 
 msgid "精准手法"
-msgstr "Precision Technique"
+msgstr "Light-fingered"
 
 msgid "在标准难度下使用【盗贼】通关游戏。"
 msgstr "Clear the game on Standard difficulty using [Rogue]."
@@ -1213,7 +1213,7 @@ msgid "骷髅王"
 msgstr "Skeleton King"
 
 msgid "死过一次……但还不够"
-msgstr "Died once... but it's not enough"
+msgstr "Died once... but that's not enough"
 
 msgid "骑士首领"
 msgstr "Knight Captain"
@@ -1228,22 +1228,22 @@ msgid "创世之神！"
 msgstr "Creator God!"
 
 msgid "战斗阶段未收集的经验点数会在回合结束时部分自动收集。"
-msgstr "Uncollected experience points during combat phases are partially auto-collected at the end of rounds."
+msgstr "Uncollected XP during combat phases will be partially auto-collected at the end of rounds."
 
 msgid "切换武器会重置攻击动作，但切换武器存在冷却时间。"
 msgstr "Switching weapons resets attack animations, but has a cooldown."
 
 msgid "攻速属性对法杖类武器的攻击频率影响较小。"
-msgstr "Attack speed has less impact on staff weapons' attack frequency."
+msgstr "Attack speed has less impact on the attack frequency of magic staff weapons."
 
 msgid "不同武器对各属性的利用效率不同。"
-msgstr "Different weapons have varying efficiency in utilizing attributes."
+msgstr "Different weapons have varying efficiency in utilizing stats."
 
 msgid "幸运属性会影响宝箱中的道具等级分布。幸运属性过低时，宝箱内不会开出高级道具，且无法获得高级武器。幸运属性较高时，宝箱内会移除低等级道具。"
-msgstr "Luck affects item grade distribution in chests. Low luck prevents high-grade items and weapons. High luck removes low-grade items from chests."
+msgstr "Luck affects the item grade distribution in chests. Low luck prevents high-grade items and weapons; high luck removes low-grade items from chests."
 
 msgid "击杀体型变大的精英怪物可以获得掉落物。当有剩余道具时，掉落物固定为宝箱，否则固定为药剂。"
-msgstr "Defeating enlarged elite monsters grants drops. With remaining items, drops are fixed as chests; otherwise, fixed as potions."
+msgstr "Defeating enlarged elite monsters grants drops. When there's a remaining number of item drops, the drop must be a chest, otherwise it's a potion."
 
 msgid "生命值越低，怪物掉落药剂的概率越高。"
 msgstr "Lower HP increases the chance of monsters dropping potions."
@@ -1252,7 +1252,7 @@ msgid "连续多回合不受到伤害会获得“神秘奖励”。"
 msgstr "Taking no damage for multiple consecutive rounds grants a 'Mysterious Reward'."
 
 msgid "击败BOSS会获得丰厚的额外奖励。"
-msgstr "Defeating a BOSS grants generous additional rewards."
+msgstr "Defeating a BOSS grants generous extra rewards."
 
 msgid "回到游戏"
 msgstr "Resume Game"
@@ -1345,10 +1345,10 @@ msgid "物品"
 msgstr "Items"
 
 msgid "StatsPanel"
-msgstr "Stats Panel"
+msgstr "StatsPanel"
 
 msgid "TreasuresPanel"
-msgstr "Treasures Panel"
+msgstr "TreasuresPanel"
 
 msgid "达成成就！"
 msgstr "Achievement Unlocked!"
@@ -1391,11 +1391,11 @@ msgid ""
 "生命值会以[color=royalblue]人畜无害的蓝色[/color]显示。\n"
 "[color=red]无法解锁完整成就[/color]。"
 msgstr ""
-"Easy Difficulty:\n"
+"Easy:\n"
 "\n"
-"At the end of each round, [color=skyblue]80% of experience is automatically recovered[/color].\n"
-"Enemies have lower [color=green]health[/color] and [color=yellow]damage[/color].\n"
-"Health values are displayed in [color=royalblue]harmless blue[/color].\n"
+"At the end of each round, [color=skyblue]80% of XP is automatically collected[/color].\n"
+"Enemies have lower [color=green]HP[/color] and [color=yellow]damage[/color].\n"
+"HP will be displayed in [color=royalblue]harmless blue[/color].\n"
 "[color=red]Cannot unlock full achievements[/color]."
 
 msgid "选择"
@@ -1409,9 +1409,9 @@ msgid ""
 "游戏结束后可以进入[color=skyblue]无尽模式[/color]。\n"
 "[color=gray]这是游戏设计原本的预期难度。[/color]"
 msgstr ""
-"Standard Difficulty:\n"
+"Standard:\n"
 "\n"
-"At the end of each round, [color=red]only 50% of experience is automatically recovered[/color].\n"
+"At the end of each round, [color=red]only 50% of XP is automatically collected[/color].\n"
 "[color=red]Enemy damage increases progressively[/color].\n"
 "After game over, you can enter [color=skyblue]Endless Mode[/color].\n"
 "[color=gray]This is the originally intended difficulty of the game design.[/color]"
@@ -1423,7 +1423,7 @@ msgid "装备武器到……"
 msgstr "Equip Weapon To..."
 
 msgid "放弃"
-msgstr "Abandon"
+msgstr "Discard"
 
 msgid "角色选择"
 msgstr "Character Selection"
@@ -1435,7 +1435,7 @@ msgid "继续前进"
 msgstr "Proceed"
 
 msgid "获得道具！"
-msgstr "Acquire Item!"
+msgstr "Item acquired!"
 
 msgid "重置"
 msgstr "Reset"
@@ -1447,7 +1447,7 @@ msgid "结束"
 msgstr "Finish"
 
 msgid "我们安全了，暂时的。"
-msgstr "We're safe, for now."
+msgstr "We're safe, only for now."
 
 msgid "你听到了吗？"
 msgstr "Did you hear that?"
@@ -1507,7 +1507,7 @@ msgid "等级"
 msgstr "Level"
 
 msgid "生命值"
-msgstr "Hit Point"
+msgstr "HP"
 
 msgid "可获得道具"
 msgstr "Acquirable Items"
@@ -1561,7 +1561,7 @@ msgid "幸运"
 msgstr "Luck"
 
 msgid "生命上限"
-msgstr "Max Hit Point"
+msgstr "Max HP"
 
 msgid "护甲"
 msgstr "Armor"
@@ -1576,49 +1576,49 @@ msgid "药瓶恢复"
 msgstr "Potion Recovery"
 
 msgid "回合恢复"
-msgstr "Turn Recovery"
+msgstr "Round Recovery"
 
 msgid "物理"
 msgstr "Physical"
 
 msgid "法术"
-msgstr "Magical"
+msgstr "Spell"
 
 msgid "影响物理攻击效益。随等级提升自然增长。"
-msgstr "Affects physical attack efficiency. Naturally increases with level."
+msgstr "Affects physical attack effects. Naturally increases with level."
 
 msgid "影响法术攻击效益。随等级提升自然增长。"
-msgstr "Affects magical attack efficiency. Naturally increases with level."
+msgstr "Affects spell attack effects. Naturally increases with level."
 
 msgid "影响所有攻击效果的收益。"
-msgstr "Affects the returns of all attack effects."
+msgstr "Affects all attack effects."
 
 msgid "影响武器的攻击动作间隔。"
 msgstr "Affects the interval between weapon attack animations."
 
 msgid "影响人物移动速度。上限为2。"
-msgstr "Affects character movement speed. Cap is 2."
+msgstr "Affects the character's movement speed. Cap is 2."
 
 msgid "影响武器攻击动作的感知距离，影响近战武器的体积。"
 msgstr "Affects the perception distance of weapon attacks and the volume of melee weapons."
 
 msgid "影响武器暴击触发概率，影响攻击特效触发概率。"
-msgstr "Affects weapon critical trigger probability and attack special effect trigger probability."
+msgstr "Affects weapon crit trigger probability and attack special effect trigger probability."
 
 msgid "影响等级提升时的属性质量，影响道具品质。"
-msgstr "Affects attribute quality on leveling up and item quality."
+msgstr "Affects stat quality on leveling up and item quality."
 
 msgid "人物最大生命值。随等级提升自然增长。"
-msgstr "Character's maximum hitpoint. Naturally increases with level."
+msgstr "Character's max HP. Naturally increases with level."
 
 msgid "人物受到攻击时，按照护甲值减免一部分伤害。"
-msgstr "Reduces damage taken based on armor value."
+msgstr "Reduces damage taken based on armor value when attacked."
 
 msgid "人物受到飞行道具攻击时，依照概率免受此伤害。上限为60%。"
 msgstr "Grants a chance to avoid damage from projectile attacks. Cap is 60%."
 
 msgid "影响武器暴击伤害。"
-msgstr "Affects weapon critical damage."
+msgstr "Affects weapon crit damage."
 
 msgid "枪械"
 msgstr "Firearms"
@@ -1642,7 +1642,7 @@ msgid "投射物"
 msgstr "Projectile"
 
 msgid "本回合内可能掉落的宝箱数量。每回合会自然增加1，拾取宝箱会扣除。"
-msgstr "Number of chests that may drop this round. Increases naturally by 1 each round, and is deducted when picking up chests."
+msgstr "Number of chests that may drop in this round. Increases naturally by 1 each round, and is deducted when picking up chests."
 
 msgid "闪避"
 msgstr "Dodge"

--- a/en/en.po
+++ b/en/en.po
@@ -553,7 +553,7 @@ msgid "照亮你的内心。"
 msgstr "Illuminates your inner self."
 
 msgid "暴击会在敌人所在的位置产生一枚可以贯穿大量敌人的冰霜子弹，造成{{0}}伤害并暴击。\n"
-"每多持有一个月亮，会多产生一枚随机方向的冰霜modified子弹，但这枚子弹不会对中央的敌人造成更多次伤害。\n"
+"每多持有一个月亮，会多产生一枚随机方向的冰霜子弹，但这枚子弹不会对中央的敌人造成更多次伤害。\n"
 "这个效果有1秒的冷却。"
 msgstr "Crits create a frost bullet at the enemy's position that can penetrate many enemies, dealing {{0}} damage and critting.\n"
 "Each Moon creates an extra frost bullet in a random direction, but it won't deal more damage to the central enemy.\n"


### PR DESCRIPTION
主要做了以下訂正工作：

+ 統一譯文。原譯文存在漢語詞與英語詞的多對多映射，例如原譯文中“法術”翻譯為 spell 和 magic，保留 spell；“生命值”翻譯為 HP、Hit Point、Health Point，保留 HP；“屬性”翻譯為 attribute 和 stat，保留 stat；“暴擊”翻譯為 crit 和 critical hit，保留 crit；“棍”和“法杖”原均譯為 staff，導致“攻速属性对法杖类武器的攻击频率影响较小”的遊戲提示誤包含棍，因此將法杖改為 magic staff，等等
+ 不恰當或意境不足的翻譯，例如“非酋”原譯為 Unlucky One，現譯為 Jinx；看板娘 原譯為 Mascot Girl，現根據維基百科改正為 Kanban Musume，等等
+ 不符合英語世界背景的翻譯，例如“物理必修二”原譯為 Physics Required II，但英語國家不存在這類教材，因此改為相對流行的 Physics Fundamentals，等等
+ 其他的翻譯中的文法錯誤、語義錯誤等